### PR TITLE
Preserve state on page swipe

### DIFF
--- a/lib/screens/navigationContainer.dart
+++ b/lib/screens/navigationContainer.dart
@@ -73,10 +73,12 @@ class _NavigationState extends State<NavigationContainer> with GetItStateMixin {
             onTabTapped(index);
           },
           children: <Widget>[
-            _children[0],
-            _children[1],
-            _children[2],
-            _children[3],
+            IndexedStack(index: _navBarIndex, children: <Widget>[
+              _children[0],
+              _children[1],
+              _children[2],
+              _children[3],
+            ])
           ]),
 
       // BottomNavigationBar
@@ -172,7 +174,6 @@ class _NavigationState extends State<NavigationContainer> with GetItStateMixin {
   }
 
   void onTabTapped(int index) {
-    _pageController.jumpToPage(index);
     setState(() {
       _navBarIndex = index;
       switch (index) {


### PR DESCRIPTION
just a quick fix for an issue that annoyed me
everytime we swiped from page to page (e.g. from gyms to news) 
the pages got rerendered (progressindicator were shown)

now the state is preserved after a navigation
feels much smoother now :smoking: 