### PR TITLE
Preserve Screen States

### DIFF
--- a/lib/screens/main/gyms.dart
+++ b/lib/screens/main/gyms.dart
@@ -18,8 +18,12 @@ class GymsScreen extends StatefulWidget {
   _GymsScreenState createState() => _GymsScreenState();
 }
 
-class _GymsScreenState extends State<GymsScreen> {
+class _GymsScreenState extends State<GymsScreen>
+    with AutomaticKeepAliveClientMixin<GymsScreen> {
   final PanelController _gymsAddPanelController = PanelController();
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/main/home.dart
+++ b/lib/screens/main/home.dart
@@ -20,11 +20,15 @@ class HomeScreen extends StatefulWidget {
   _HomeScreenState createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends State<HomeScreen>
+    with AutomaticKeepAliveClientMixin<HomeScreen> {
   final authService = locator<AuthService>();
   final gymService = locator<GymService>();
   final routesService = locator<RoutesService>();
   final routeColorService = locator<RouteColorService>();
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/main/news.dart
+++ b/lib/screens/main/news.dart
@@ -14,8 +14,17 @@ import 'package:sliding_up_panel/sliding_up_panel.dart';
 
 const polyDark = Color(0x121212);
 
-class NewsScreen extends StatelessWidget with GetItMixin {
+class NewsScreen extends StatefulWidget with GetItStatefulWidgetMixin {
+  @override
+  _NewsScreenState createState() => _NewsScreenState();
+}
+
+class _NewsScreenState extends State<NewsScreen>
+    with GetItStateMixin, AutomaticKeepAliveClientMixin<NewsScreen> {
   final PanelController _newsAddPanelController = PanelController();
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/main/routes.dart
+++ b/lib/screens/main/routes.dart
@@ -20,7 +20,8 @@ class RoutesScreen extends StatefulWidget {
   _RoutesScreenState createState() => _RoutesScreenState();
 }
 
-class _RoutesScreenState extends State<RoutesScreen> {
+class _RoutesScreenState extends State<RoutesScreen>
+    with AutomaticKeepAliveClientMixin<RoutesScreen> {
   final routesService = locator<RoutesService>();
   final routeColorService = locator<RouteColorService>();
   GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey();
@@ -30,6 +31,10 @@ class _RoutesScreenState extends State<RoutesScreen> {
   int _routeStateFilterIndex = 0;
 
   PanelController addPanelController = PanelController();
+
+  @override
+  bool get wantKeepAlive => true;
+
   @override
   Widget build(BuildContext context) {
     final auth = locator<AuthService>();

--- a/lib/screens/navigationContainer.dart
+++ b/lib/screens/navigationContainer.dart
@@ -70,15 +70,13 @@ class _NavigationState extends State<NavigationContainer> with GetItStateMixin {
               : new NeverScrollableScrollPhysics(),
           controller: _pageController,
           onPageChanged: (index) {
-            onTabTapped(index);
+            changeTitle(index);
           },
           children: <Widget>[
-            IndexedStack(index: _navBarIndex, children: <Widget>[
-              _children[0],
-              _children[1],
-              _children[2],
-              _children[3],
-            ])
+            _children[0],
+            _children[1],
+            _children[2],
+            _children[3],
           ]),
 
       // BottomNavigationBar
@@ -173,7 +171,13 @@ class _NavigationState extends State<NavigationContainer> with GetItStateMixin {
     }
   }
 
-  void onTabTapped(int index) {
+  void onTabTapped(int index) async {
+    await _pageController.animateToPage(index,
+        duration: Duration(milliseconds: 100), curve: Curves.easeOut);
+    changeTitle(index);
+  }
+
+  void changeTitle(int index) {
     setState(() {
       _navBarIndex = index;
       switch (index) {


### PR DESCRIPTION
this implements to things :

1.
everytime we swiped from page to page (e.g. from gyms to news)
the pages got rerendered (progressindicator were shown)
--> now the state is preserved after a navigation which feels much smoother

2.
it implements a swipe animation when you press on a item of the bottomnavbar
please let me know if you like the animation, we can adjust the parameters Duration and Curve :)