### PR TITLE
Disable background while having a opened sliding up panel

### DIFF
--- a/lib/widgets/slidingUpPanel.dart
+++ b/lib/widgets/slidingUpPanel.dart
@@ -74,6 +74,8 @@ class _SlidingUpPanelState extends State<PolySlidingUpPanel> {
       controller: controller,
       panel: panel,
       panelBuilder: panelBuilder,
+      backdropEnabled: true,
+      backdropTapClosesPanel: true,
       onPanelClosed: (() {
         pageviewService.setSwipingAllowed(true);
         setState(() {});


### PR DESCRIPTION
The background is disabled while having a opened sliding up panel.
In addition the sliding up panel closes, when tapping outside the panel.