### PR TITLE
Limit input of category name to 12

### DIFF
--- a/lib/widgets/routes/routeAddPanel.dart
+++ b/lib/widgets/routes/routeAddPanel.dart
@@ -357,6 +357,7 @@ class _RouteAddPanelState extends State<RouteAddPanel> {
                                         keyboardType: TextInputType.text,
                                         // The type should consist of only one line
                                         maxLines: 1,
+                                        maxLength: 12,
                                         decoration: InputDecoration(
                                             hintText: 'e.g. Competition',
                                             contentPadding:


### PR DESCRIPTION
Fix #218 by limiting the input characters of the category name to 12.