### PR TITLE
fix uppercase bug and add Divider height for Button visibility in Pannels

### DIFF
--- a/lib/widgets/gyms/gymsAddPanel.dart
+++ b/lib/widgets/gyms/gymsAddPanel.dart
@@ -260,7 +260,9 @@ class _GymsAddPanelState extends State<GymsAddPanel> {
                         ],
                       ),
                     ),
-                    Divider()
+                    Divider(
+                      height: 64,
+                    ),
                   ],
                 )))));
   }

--- a/lib/widgets/gyms/gymsAddPanel.dart
+++ b/lib/widgets/gyms/gymsAddPanel.dart
@@ -260,7 +260,7 @@ class _GymsAddPanelState extends State<GymsAddPanel> {
                         ],
                       ),
                     ),
-                    Divider(
+                    Container(
                       height: 64,
                     ),
                   ],

--- a/lib/widgets/gyms/gymsEditPanel.dart
+++ b/lib/widgets/gyms/gymsEditPanel.dart
@@ -329,7 +329,7 @@ class _GymsEditPanelState extends State<GymsEditPanel> with GetItStateMixin {
                             );
                           }
                         }),
-                    Divider(
+                    Container(
                       height: 64,
                     ),
                   ],

--- a/lib/widgets/gyms/gymsEditPanel.dart
+++ b/lib/widgets/gyms/gymsEditPanel.dart
@@ -329,7 +329,9 @@ class _GymsEditPanelState extends State<GymsEditPanel> with GetItStateMixin {
                             );
                           }
                         }),
-                    Divider()
+                    Divider(
+                      height: 64,
+                    ),
                   ],
                 )))));
   }

--- a/lib/widgets/news/newsAddPanel.dart
+++ b/lib/widgets/news/newsAddPanel.dart
@@ -294,7 +294,7 @@ class _NewsAddPanelState extends State<NewsAddPanel> {
                         ],
                       ),
                     ),
-                    Divider(
+                    Container(
                       height: 64,
                     ),
                   ],

--- a/lib/widgets/news/newsAddPanel.dart
+++ b/lib/widgets/news/newsAddPanel.dart
@@ -171,7 +171,8 @@ class _NewsAddPanelState extends State<NewsAddPanel> {
                                   controller: controllerNewsContent,
                                   validator: ContentFieldValidator.validate,
                                   autocorrect: false,
-                                  textCapitalization: TextCapitalization.words,
+                                  textCapitalization:
+                                      TextCapitalization.sentences,
                                   style: Constants.defaultText,
                                   // The news body may contains multiple lines, so enter should insert a newline
                                   keyboardType: TextInputType.multiline,
@@ -292,7 +293,10 @@ class _NewsAddPanelState extends State<NewsAddPanel> {
                           ),
                         ],
                       ),
-                    )
+                    ),
+                    Divider(
+                      height: 64,
+                    ),
                   ],
                 ),
               ),

--- a/lib/widgets/routes/routeAddPanel.dart
+++ b/lib/widgets/routes/routeAddPanel.dart
@@ -477,7 +477,7 @@ class _RouteAddPanelState extends State<RouteAddPanel> {
                                         maxLength: Constants.routeNoteLength,
                                         autocorrect: false,
                                         textCapitalization:
-                                            TextCapitalization.words,
+                                            TextCapitalization.sentences,
                                         style: TextStyle(
                                             fontWeight: FontWeight.w800),
                                         // The name keyboard is optimized for names and phone numbers
@@ -574,7 +574,9 @@ class _RouteAddPanelState extends State<RouteAddPanel> {
                                   ),
                                 ],
                               )),
-                          Divider()
+                          Divider(
+                            height: 64,
+                          ),
                         ],
                       ))));
         });

--- a/lib/widgets/routes/routeAddPanel.dart
+++ b/lib/widgets/routes/routeAddPanel.dart
@@ -574,7 +574,7 @@ class _RouteAddPanelState extends State<RouteAddPanel> {
                                   ),
                                 ],
                               )),
-                          Divider(
+                          Container(
                             height: 64,
                           ),
                         ],

--- a/lib/widgets/routes/routeEditPanel.dart
+++ b/lib/widgets/routes/routeEditPanel.dart
@@ -668,7 +668,7 @@ class _RouteEditPanelState extends State<RouteEditPanel> with GetItStateMixin {
                                       ],
                                     ),
                                   ),
-                                  Divider(
+                                  Container(
                                     height: 64,
                                   ),
                                 ],

--- a/lib/widgets/routes/routeEditPanel.dart
+++ b/lib/widgets/routes/routeEditPanel.dart
@@ -497,7 +497,8 @@ class _RouteEditPanelState extends State<RouteEditPanel> with GetItStateMixin {
                                                     Constants.routeNoteLength,
                                                 autocorrect: false,
                                                 textCapitalization:
-                                                    TextCapitalization.words,
+                                                    TextCapitalization
+                                                        .sentences,
                                                 style: TextStyle(
                                                     fontWeight:
                                                         FontWeight.w800),
@@ -667,7 +668,9 @@ class _RouteEditPanelState extends State<RouteEditPanel> with GetItStateMixin {
                                       ],
                                     ),
                                   ),
-                                  Divider()
+                                  Divider(
+                                    height: 64,
+                                  ),
                                 ],
                               ));
                         }


### PR DESCRIPTION
- fix uppercase keyboard Bug in News Text and Route Notes Field
- add Container height so that the buttons are visible by scrolling although an opened keyboard.
  - even if the keyboard cannot be closed in the Notes field under iOS (press return = newline), this isn't a problem anymore

i have tested nativly on iphone 11, ipod toch 7gen, iphone 12 mini
 
fix #365 